### PR TITLE
chore(README.md): Add link to wiki in the README

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -2,6 +2,10 @@
 
 ReVanced Extended Patches.
 
+## Documentation
+
+Check the [wiki](https://github.com/anddea/revanced-patches/wiki) for resources on patching, customization, and debugging.
+
 ## 📋 List of patches in this repository
 
 {{ table }}

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 ReVanced Extended Patches.
 
-## Documentation
-
-Check the [wiki](https://github.com/anddea/revanced-patches/wiki) for resources on patching, customization, and debugging.
-
 ## 📋 List of patches in this repository
 
 ### [📦 `com.google.android.youtube`](https://play.google.com/store/apps/details?id=com.google.android.youtube)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ReVanced Extended Patches.
 
+## Documentation
+
+Check the [wiki](https://github.com/anddea/revanced-patches/wiki) for resources on patching, customization, and debugging.
+
 ## 📋 List of patches in this repository
 
 ### [📦 `com.google.android.youtube`](https://play.google.com/store/apps/details?id=com.google.android.youtube)


### PR DESCRIPTION
Fixes https://github.com/anddea/revanced-patches/issues/808

I can't PR to the wiki, so here is syntax you can use. Feel free to change anything or edit the bottom half of the image:

> To patch with the ReVanced/RVX Manager or with the rvx-builder, the sources must be set as follows:
> 
> **Patches organization:**
> ```
> anddea
> ```
> 
> **Patches source:**
> ```
> revanced-patches
> ```
> 
> **Integrations organization:**
> ```
> anddea
> ```
> 
> **Integrations source:**
> ```
> revanced-integrations
> ```
> 
> <details>
> <summary><strong>Screenshot</strong></summary>
> <br>
>   <img src="https://github.com/user-attachments/assets/69a0e32f-76af-4dae-bc46-7dce35192f9d" alt="source_example" width="500"/>
> </details>

For the screenshot dropdown, this is the syntax I used: (i couldn't put the entire thing in codeblocks bec of the source codeblocks)

```
<details>
<summary><strong>Screenshot</strong></summary>
<br>
  <img src="https://github.com/user-attachments/assets/69a0e32f-76af-4dae-bc46-7dce35192f9d" alt="source_example" width="500"/>
</details>
```



```