### PR TITLE
chore: Refine bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -29,7 +29,6 @@ body:
       options:
         - Morphe Manager
         - URV Manager
-        - rvx-builder
         - Revancify/Enhancify
         - Morphe CLI
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,7 +10,7 @@ body:
 
         Before creating a new bug report, please keep the following in mind:
 
-        - If your bug is not related to [unique features](https://github.com/anddea/revanced-patches/wiki/Unique-features), open your bug report in [ReVanced](https://github.com/ReVanced/revanced-patches/issues) and [RVX](https://github.com/inotia00/ReVanced_Extended/issues) first.
+        - If your bug is not related to [unique features](https://github.com/anddea/revanced-patches/wiki/Unique-features), open your bug report in [Morphe](https://github.com/MorpheApp/morphe-patches/issues) first.
         - **Do not submit a duplicate bug report**: You can review existing bug reports [here](https://github.com/anddea/revanced-patches/labels/Bug%20report).
         - **Check if this issue reproduces in unpatched apps as well**: Most bugs can also be reproduced in unpatched apps.
   - type: dropdown
@@ -37,7 +37,7 @@ body:
     attributes:
       label: Application
       description: Write down the application and version where the issue occurs.
-      placeholder: e.g. YouTube v19.16.39
+      placeholder: e.g. YouTube v20.05.46
     validations:
       required: true
   - type: textarea
@@ -80,7 +80,7 @@ body:
           required: true
         - label: I did not use any settings marked as `Experimental Flags`.
           required: true
-        - label: I have patched the APK according to the [documentation](https://github.com/inotia00/revanced-documentation#readme).
+        - label: I have patched the APK myself.
           required: true
         - label: I have chosen an appropriate title.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,10 +27,11 @@ body:
     attributes:
       label: Tools used
       options:
-        - RVX Manager
+        - Morphe Manager
+        - URV Manager
         - rvx-builder
-        - Revancify
-        - CLI
+        - Revancify/Enhancify
+        - Morphe CLI
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary

+ Links for Revanced and Revanced Extended (inotia00) have been removed and replaced with Morphe.

+ The deprecated tools from the dropdown menu has been removed, Morphe Manager, URV Manager, and Enhancify have been added.

+ The placeholder version information for YouTube has been replaced with the version "YouTube 20.05.46."

+ Minor acknowledgement changes