### PR TITLE
fix(YouTube): Restore external downloader PiP guard on 21.04+

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/youtube/utils/pip/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/utils/pip/Fingerprints.kt
@@ -16,3 +16,15 @@ internal val pipPlaybackFingerprint = legacyFingerprint(
         Opcode.IF_NEZ
     )
 )
+
+internal val pipPlaybackModernFingerprint = legacyFingerprint(
+    name = "pipPlaybackModernFingerprint",
+    returnType = "Lcom/google/common/util/concurrent/ListenableFuture;",
+    parameters = listOf("Landroid/view/View;"),
+    strings = listOf("Error entering picture and picture"),
+    opcodes = listOf(
+        Opcode.INVOKE_DIRECT,
+        Opcode.MOVE_RESULT,
+        Opcode.IF_NEZ
+    )
+)

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/utils/pip/PiPStateHookPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/utils/pip/PiPStateHookPatch.kt
@@ -18,9 +18,11 @@ val pipStateHookPatch = bytecodePatch(
     dependsOn(versionCheckPatch)
 
     execute {
-        if (is_21_04_or_greater) return@execute
+        val pipFingerprint =
+            if (is_21_04_or_greater) pipPlaybackModernFingerprint
+            else pipPlaybackFingerprint
 
-        pipPlaybackFingerprint.matchOrThrow().let {
+        pipFingerprint.matchOrThrow().let {
             it.method.apply {
                 val insertIndex = it.instructionMatches.last().index
                 val insertRegister = getInstruction<OneRegisterInstruction>(insertIndex).registerA


### PR DESCRIPTION
## Problem

On supported YouTube 21.07.247, returning from an external downloader can intermittently leave the video player alive while the watch-page body (including comments) stays empty until the app process is restarted.

Reproduction path:
1. Open a video.
2. Tap the RVX overlay external-download button (YTDLnis in this case).
3. Press Back from the downloader screen.

No crash or ANR was observed. The lifecycle transition is the distinguishing event.

`VideoUtils.launchVideoExternalDownloader()` still sets `isExternalDownloaderLaunched`, but `pipStateHookPatch` returns early on YouTube 21.04+, so that state is never consumed. YouTube 21.04+ replaced the legacy `PlayerResponseModel` PiP eligibility path with a watch-activity `onUserLeaveHint` path.

## Fix

- Fingerprint the modern PiP eligibility check by its method signature, diagnostic string, and `INVOKE_DIRECT` / `MOVE_RESULT` / `IF_NEZ` sequence.
- Apply the existing `getExternalDownloaderLaunchedState` hook to that eligibility result on YouTube 21.04+.
- Preserve the existing legacy fingerprint and injection path for older versions.

## Validation

- [x] `:patches:buildAndroid --no-daemon` succeeds on Java 21.
- [x] The modern fingerprint has one match in the unmodified YouTube 21.07.247 DEX.
- [x] The selected result is the eligibility branch reached directly from `MainActivity.onUserLeaveHint()`.
- [x] The CI-built MPP applies `Overlay buttons` to YouTube 21.07.247 with FULL bytecode compilation and no failed patches.
- [x] Patched-DEX inspection confirms the hook is inserted between the modern eligibility `MOVE_RESULT` and `IF_NEZ`.
- [x] The rebuilt APK passes ZIP integrity validation.

The failure is intermittent, so the change is intentionally narrow: it restores only the downloader transition guard that the legacy implementation already had.

Independent validation run: https://github.com/COOLak/anddea-revanced-patches/actions/runs/34070643753

Upstream Actions currently reports `action_required` because this is a first-time-contributor PR and requires maintainer approval before its copy of the workflow can start.