### PR TITLE
fix(YouTube - Custom branding): avoid quadratic Android DOM scans

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/CustomBrandingUtils.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/shared/layout/branding/CustomBrandingUtils.kt
@@ -332,7 +332,8 @@ internal fun ResourcePatchContext.applyCustomBranding(
             .ifBlank { application.getAttribute("android:theme") }
             .takeIf(String::isNotBlank)
             ?: throw PatchException("Could not find the main activity theme")
-        val sourceChildren = List(source.childNodes.length) { source.childNodes.item(it) }
+        val childNodes = source.childNodes
+        val sourceChildren = List(childNodes.length) { childNodes.item(it) }
 
         // This entry must remain a standard activity. Inheriting the host's singleTask launch mode
         // prevents its forwarded MainActivity intent from opening in the current launcher task.
@@ -1137,8 +1138,9 @@ internal fun ResourcePatchContext.addCustomBrandingSystemSplashThemeStyles() {
         "${BrandingResource.SYSTEM_SPLASH_STYLE.resourceName}_"
     val systemSplashStyleNames = document("res/values-v31/styles.xml").use { document ->
         val resources = document.documentElement
-        (0 until resources.childNodes.length)
-            .map { resources.childNodes.item(it) }
+        val childNodes = resources.childNodes
+        (0 until childNodes.length)
+            .map { childNodes.item(it) }
             .filterIsInstance<Element>()
             .filter { element ->
                 element.tagName == "style" &&
@@ -1151,8 +1153,9 @@ internal fun ResourcePatchContext.addCustomBrandingSystemSplashThemeStyles() {
 
     val themeSplashStyleNames = document("res/values-v31/styles.xml").use { document ->
         val resources = document.documentElement
-        (0 until resources.childNodes.length)
-            .map { resources.childNodes.item(it) }
+        val childNodes = resources.childNodes
+        (0 until childNodes.length)
+            .map { childNodes.item(it) }
             .filterIsInstance<Element>()
             .filter { element ->
                 val name = element.getAttribute("name")
@@ -1170,8 +1173,9 @@ internal fun ResourcePatchContext.addCustomBrandingSystemSplashThemeStyles() {
 
         document(path).use { document ->
             val resources = document.documentElement
-            val sourceSystemStyles = (0 until resources.childNodes.length)
-                .map { resources.childNodes.item(it) }
+            val childNodes = resources.childNodes
+            val sourceSystemStyles = (0 until childNodes.length)
+                .map { childNodes.item(it) }
                 .filterIsInstance<Element>()
                 .filter { it.tagName == "style" }
                 .associateBy { it.getAttribute("name") }
@@ -1500,8 +1504,11 @@ private fun addStringArray(resources: Element, name: String, values: List<String
 }
 
 private fun removeResource(resources: Element, tagName: String, name: String) {
-    for (index in resources.childNodes.length - 1 downTo 0) {
-        val element = resources.childNodes.item(index) as? Element ?: continue
+    // Android's DOM copies the children on every getChildNodes() call.
+    // Take one snapshot and remove backwards so both snapshot and live lists work.
+    val childNodes = resources.childNodes
+    for (index in childNodes.length - 1 downTo 0) {
+        val element = childNodes.item(index) as? Element ?: continue
         if (element.tagName == tagName && element.getAttribute("name") == name) {
             resources.removeChild(element)
         }


### PR DESCRIPTION
Morphe Manager can spend minutes finalizing YouTube branding on Android. `ElementImpl.getChildNodes()` in Android's DOM returns a copied list, but the branding loops call it again for every indexed child. Repeated style removal amplifies the allocations and garbage collection.

Cache one `NodeList` per scan, including the three splash-style scans and backwards resource removal. Backwards removal preserves behavior for both snapshot and live node lists. This also avoids repeated snapshots when copying an activity's children.

Validation on a Samsung SM-S928B with Morphe Manager 1.30.0-dev.3, YouTube 21.07.247, and the same 75-patch selection:
- A 4,000-style, ten-scan Android DOM probe: 5,665 ms before, 6 ms after, identical checksum 348900.
- Before: last ordinary patch at 09:12:14.470, branding finalization at 09:20:35.135 (500.665 seconds).
- After: Voice Over Translation at 09:25:21.422 and branding finalization at 09:25:21.852; all 75 patches passed.
- Kotlin compilation and Android bundle build passed. Morphe completed and signed the 216,974,452-byte APK in 375,212 ms (6m15.212s) total; its signer matches the previous installed build.

The earlier RVX 4.3.0-dev.5 build on this device also logged `elapsed=811867ms` (13m31.867s) for the same YouTube version and 75-patch selection. This historical total includes both patch application and APK assembly.

This fixes the branding scan cost. APK resource compilation/assembly remains a separate phase and is not covered by the timing improvement above.

Related: #1761, whose reports identify the same late custom-branding stall on Android.
